### PR TITLE
Add orchestration script for full data pipeline

### DIFF
--- a/docs/run_all_pipeline.md
+++ b/docs/run_all_pipeline.md
@@ -1,0 +1,70 @@
+# Run-All Pipeline Script
+
+This guide explains how to use `scripts/run_all_pipeline.py` to execute the
+entire GDPR enforcement data pipeline (Phases 1–4) in a single command. The
+script orchestrates the existing phase helpers without duplicating their
+logic, ensuring that each stage reads the exact output from the previous one.
+
+## Key Features
+
+- Accepts either a path to an `AI-responses.txt` style file or raw response
+  text supplied via the `--input-text` flag.
+- Reuses the phase modules directly (`run_phase1`, `run_phase2`,
+  `run_phase3`, `enrich_dataset`) so the data flow mirrors the documented
+  pipeline.
+- Writes all artefacts to the standard `/outputs/phase*_*/` directories by
+  default, while allowing overrides through `--output-root`.
+- Automatically re-validates the repaired dataset before triggering Phase 4
+  enrichment.
+
+## Usage
+
+```bash
+python scripts/run_all_pipeline.py \
+  --input-file raw_data/AI_analysis/AI-responses.txt
+```
+
+### Optional Flags
+
+| Flag | Purpose |
+| --- | --- |
+| `--input-text "…"` | Provide raw AI response text directly. The script creates a temporary file and removes it after the run (unless `--keep-temp-input` is set). |
+| `--output-root <path>` | Store all phase outputs under a different root directory while retaining per-phase subfolders. |
+| `--skip-enrichment` | Execute only Phases 1–3 and skip the enrichment helpers. |
+| `--keep-temp-input` | Preserve the temporary file generated from `--input-text`. |
+
+## Phase-by-Phase Workflow
+
+1. **Phase 1 – Extraction**
+   - Calls `run_phase1` from `scripts/1_parse_ai_responses.py`.
+   - Input: AI response text (from `--input-file` or the temporary file created for `--input-text`).
+   - Output: `/outputs/phase1_extraction/main_dataset.csv` and supporting logs/errors inside the same folder.
+
+2. **Phase 2 – Validation**
+   - Calls `run_phase2` from `scripts/2_validate_dataset.py` on the Phase 1 CSV.
+   - Output: `/outputs/phase2_validation/validated_data.csv`, `validation_errors.csv`, and `validation_report.txt`.
+   - The generated `validation_errors.csv` is passed directly into Phase 3 when present.
+
+3. **Phase 3 – Repair**
+   - Invokes `run_phase3` from `scripts/3_repair_data_errors.py` using the Phase 1 dataset plus the Phase 2 error ledger.
+   - Output: `/outputs/phase3_repair/repaired_dataset.csv` and `repair_log.txt`.
+   - Immediately re-validates the repaired dataset, producing `repaired_dataset_validated.csv` (clean subset) and updated validation artefacts in the same folder.
+
+4. **Phase 4 – Enrichment (optional)**
+   - Unless `--skip-enrichment` is supplied, calls `enrich_dataset` from `scripts/4_enrich_prepare_outputs.py`.
+   - Input: `/outputs/phase3_repair/repaired_dataset.csv`.
+   - Output: `/outputs/phase4_enrichment/` bundle (master dataset, long tables, and graph exports).
+
+The script prints a concise summary of the generated files at the end of the run so you can quickly locate the artefacts for downstream analysis.
+
+## Tips
+
+- The underlying modules enforce the schema documented in
+  `schema/main-schema-critically-important.md`, so schema updates will flow
+  through the pipeline automatically.
+- When experimenting with alternate output locations (via `--output-root`),
+  remember that Phase 4 still expects the FX and HICP references from
+  `raw_data/reference/`.
+- For iterative debugging, use `--skip-enrichment` to accelerate runs and
+  inspect the repair + revalidation outputs before generating the enriched
+  bundle.

--- a/scripts/3_repair_data_errors.py
+++ b/scripts/3_repair_data_errors.py
@@ -16,6 +16,7 @@ import csv
 from pathlib import Path
 from datetime import datetime
 from collections import defaultdict
+from typing import Any, Dict, Optional
 
 # Define repair rules
 REPAIR_RULES = {
@@ -263,42 +264,67 @@ def repair_dataset(input_file: str, error_file: str, output_file: str, log_file:
     return rows_repaired, sum(all_repairs.values())
 
 
-def main():
-    # Paths
+def run_phase3(
+    input_file: Path,
+    error_file: Path,
+    output_file: Optional[Path] = None,
+    log_file: Optional[Path] = None,
+    *,
+    verbose: bool = True,
+) -> Dict[str, Any]:
+    """Execute phase 3 repairs with configurable paths."""
+
     script_dir = Path(__file__).parent
     project_root = script_dir.parent
-    input_file = project_root / 'outputs' / 'phase1_extraction' / 'main_dataset.csv'
-    error_file = project_root / 'outputs' / 'phase2_validation' / 'validation_errors.csv'
-    output_file = project_root / 'outputs' / 'phase3_repair' / 'repaired_dataset.csv'
-    log_file = project_root / 'outputs' / 'phase3_repair' / 'repair_log.txt'
 
-    # Ensure output directory exists
+    if output_file is None:
+        output_file = project_root / 'outputs' / 'phase3_repair' / 'repaired_dataset.csv'
+    if log_file is None:
+        log_file = output_file.parent / 'repair_log.txt'
+
     output_file.parent.mkdir(parents=True, exist_ok=True)
 
-    print("=" * 70)
-    print("Phase 3: Auto-Repair Data Errors")
-    print("=" * 70)
-    print(f"Input:  {input_file}")
-    print(f"Errors: {error_file}")
-    print(f"Output: {output_file}")
-    print(f"Log:    {log_file}")
-    print()
+    if verbose:
+        print("=" * 70)
+        print("Phase 3: Auto-Repair Data Errors")
+        print("=" * 70)
+        print(f"Input:  {input_file}")
+        print(f"Errors: {error_file}")
+        print(f"Output: {output_file}")
+        print(f"Log:    {log_file}")
+        print()
 
-    # Repair
     rows_repaired, total_repairs = repair_dataset(
         str(input_file), str(error_file), str(output_file), str(log_file)
     )
 
-    print()
-    print(f"✓ Wrote repaired dataset to {output_file.name}")
-    print(f"✓ Wrote repair log to {log_file.name}")
+    if verbose:
+        print()
+        print(f"✓ Wrote repaired dataset to {output_file.name}")
+        print(f"✓ Wrote repair log to {log_file.name}")
+        print()
+        print("=" * 70)
+        print("✓ Phase 3 repair complete!")
+        print("=" * 70)
+        print("\nNext step: Re-run Phase 2 validation on repaired dataset")
+        print("  python3 scripts/2_validate_dataset.py --input outputs/phase3_repair/repaired_dataset.csv")
 
-    print()
-    print("=" * 70)
-    print("✓ Phase 3 repair complete!")
-    print("=" * 70)
-    print(f"\nNext step: Re-run Phase 2 validation on repaired dataset")
-    print(f"  python3 scripts/2_validate_dataset.py --input outputs/phase3_repair/repaired_dataset.csv")
+    return {
+        'input_file': input_file,
+        'error_file': error_file,
+        'repaired_csv': output_file,
+        'log_file': log_file,
+        'rows_repaired': rows_repaired,
+        'total_repairs': total_repairs,
+    }
+
+
+def main():
+    script_dir = Path(__file__).parent
+    project_root = script_dir.parent
+    input_file = project_root / 'outputs' / 'phase1_extraction' / 'main_dataset.csv'
+    error_file = project_root / 'outputs' / 'phase2_validation' / 'validation_errors.csv'
+    run_phase3(input_file, error_file, verbose=True)
 
 
 if __name__ == '__main__':

--- a/scripts/run_all_pipeline.py
+++ b/scripts/run_all_pipeline.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Run the full GDPR enforcement data pipeline end-to-end."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+def load_module(name: str, relative_path: str):
+    """Dynamically load a phase module by path."""
+
+    module_path = PROJECT_ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(name, module_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load module from {module_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def resolve_path(path: Path) -> Path:
+    """Resolve paths relative to the project root."""
+
+    return path if path.is_absolute() else (PROJECT_ROOT / path).resolve()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run phases 1-4 sequentially using in-repo helpers.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--input-file",
+        type=Path,
+        help="Path to an AI responses text file (Answer N format).",
+    )
+    parser.add_argument(
+        "--input-text",
+        type=str,
+        help="Raw AI responses text. When provided, the script writes it to a temporary file before processing.",
+    )
+    parser.add_argument(
+        "--output-root",
+        type=Path,
+        default=PROJECT_ROOT / "outputs",
+        help="Root directory for phase output folders.",
+    )
+    parser.add_argument(
+        "--skip-enrichment",
+        action="store_true",
+        help="Skip Phase 4 enrichment (Phases 1-3 still run).",
+    )
+    parser.add_argument(
+        "--keep-temp-input",
+        action="store_true",
+        help="Preserve the temporary file created from --input-text.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    if args.input_file and args.input_text:
+        raise SystemExit("Provide either --input-file or --input-text, not both.")
+
+    output_root = resolve_path(args.output_root)
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    temp_input_path: Optional[Path] = None
+
+    if args.input_text:
+        tmp_dir = output_root / "tmp"
+        tmp_dir.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False, dir=tmp_dir) as tmp_file:
+            tmp_file.write(args.input_text)
+            temp_input_path = Path(tmp_file.name)
+        input_path = temp_input_path
+        print(f"Created temporary AI response file at {input_path}")
+    elif args.input_file:
+        input_path = resolve_path(args.input_file)
+    else:
+        input_path = PROJECT_ROOT / "raw_data" / "AI_analysis" / "AI-responses.txt"
+
+    if not input_path.exists():
+        raise SystemExit(f"Input file not found: {input_path}")
+
+    phase1_module = load_module("phase1_parser", "scripts/1_parse_ai_responses.py")
+    phase2_module = load_module("phase2_validator", "scripts/2_validate_dataset.py")
+    phase3_module = load_module("phase3_repair", "scripts/3_repair_data_errors.py")
+
+    phase1_dir = output_root / "phase1_extraction"
+    phase1_results: Dict[str, Any] = phase1_module.run_phase1(input_path, output_dir=phase1_dir, verbose=True)
+    main_dataset_path = Path(phase1_results["main_csv"])
+
+    phase2_dir = output_root / "phase2_validation"
+    phase2_validated_path = phase2_dir / "validated_data.csv"
+    phase2_errors_path = phase2_dir / "validation_errors.csv"
+    phase2_report_path = phase2_dir / "validation_report.txt"
+    phase2_results: Dict[str, Any] = phase2_module.run_phase2(
+        main_dataset_path,
+        output_validated=phase2_validated_path,
+        output_errors=phase2_errors_path,
+        output_report=phase2_report_path,
+        verbose=True,
+    )
+
+    error_csv_path = phase2_results.get("errors_csv")
+    if error_csv_path is None or not Path(error_csv_path).exists():
+        print("No validation errors detected; skipping Phase 3 automatic repairs.")
+        repaired_dataset_path = main_dataset_path
+    else:
+        phase3_dir = output_root / "phase3_repair"
+        repaired_dataset_path = phase3_dir / "repaired_dataset.csv"
+        repair_log_path = phase3_dir / "repair_log.txt"
+        phase3_results: Dict[str, Any] = phase3_module.run_phase3(
+            main_dataset_path,
+            Path(error_csv_path),
+            output_file=repaired_dataset_path,
+            log_file=repair_log_path,
+            verbose=True,
+        )
+        repaired_dataset_path = Path(phase3_results["repaired_csv"])
+
+    phase3_dir = output_root / "phase3_repair"
+    revalidation_results = phase2_module.run_phase2(
+        repaired_dataset_path,
+        output_validated=phase3_dir / "repaired_dataset_validated.csv",
+        output_errors=phase3_dir / "repaired_dataset_validation_errors.csv",
+        output_report=phase3_dir / "repaired_dataset_validation_report.txt",
+        verbose=True,
+    )
+
+    if not args.skip_enrichment:
+        phase4_module = load_module("phase4_enrich", "scripts/4_enrich_prepare_outputs.py")
+        enrichment_dir = output_root / "phase4_enrichment"
+        enrichment_dir.mkdir(parents=True, exist_ok=True)
+        fx_table = PROJECT_ROOT / "raw_data" / "reference" / "fx_rates.csv"
+        hicp_table = PROJECT_ROOT / "raw_data" / "reference" / "hicp_ea19.csv"
+        phase4_module.enrich_dataset(repaired_dataset_path, enrichment_dir, fx_table, hicp_table)
+        print(f"✓ Phase 4 enrichment complete. Outputs written to {enrichment_dir}")
+    else:
+        print("Phase 4 enrichment skipped by user request.")
+
+    if temp_input_path and not args.keep_temp_input:
+        temp_input_path.unlink(missing_ok=True)
+        print(f"Removed temporary input file {temp_input_path}")
+
+    print("\nPipeline summary:")
+    print(f"  Phase 1 main dataset: {main_dataset_path}")
+    validated_csv = phase2_results.get("validated_csv")
+    if validated_csv:
+        print(f"  Phase 2 validated subset: {validated_csv}")
+    errors_csv = phase2_results.get("errors_csv")
+    if errors_csv:
+        print(f"  Phase 2 error ledger: {errors_csv}")
+    print(f"  Phase 3 revalidated dataset: {revalidation_results.get('validated_csv')}")
+    if not args.skip_enrichment:
+        print(f"  Phase 4 directory: {output_root / 'phase4_enrichment'}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `scripts/run_all_pipeline.py` to execute phases 1–4 sequentially with CLI flags for input text, alternate output roots, and optional enrichment
- expose reusable `run_phase1`, `run_phase2`, and `run_phase3` helpers in the existing phase scripts so other tooling can call them programmatically
- document end-to-end usage in a dedicated `docs/run_all_pipeline.md`

## Testing
- python scripts/run_all_pipeline.py --skip-enrichment

------
https://chatgpt.com/codex/tasks/task_e_68e1287df198832e830aadb944f9cbb4