### PR TITLE
Harden pipeline schema integrity checks

### DIFF
--- a/docs/pipeline_phase1-4_review.md
+++ b/docs/pipeline_phase1-4_review.md
@@ -59,14 +59,17 @@
 1. **Critical – Strengthen Data Integrity Guards**
    - Deduplicate and collision-check `id` values during Phase 1; halt or quarantine duplicates to preserve referential integrity.【F:scripts/1_parse_ai_responses.py†L90-L158】
    - Embed schema version hashes into validation/repair outputs and verify Phase 3 consumes a matching schema snapshot before applying repairs, preventing misaligned rewrites.【F:scripts/2_validate_dataset.py†L368-L464】【F:scripts/3_repair_data_errors.py†L170-L286】
+   - _Status update:_ Phase 1 now quarantines duplicate IDs and records the raw response block, while Phases 2–3 exchange and verify `schema_snapshot.json` manifests before applying repairs.【F:scripts/1_parse_ai_responses.py†L96-L158】【F:scripts/2_validate_dataset.py†L617-L704】【F:scripts/3_repair_data_errors.py†L210-L357】
 
 2. **High – Preserve Uncertainty & Traceability**
    - Reclassify `NOT_DISCUSSED` repairs in binary fields as warnings requiring manual adjudication or add a confidence column documenting automated coercions.【F:scripts/3_repair_data_errors.py†L24-L87】
    - Store full malformed response blocks (not just parsed dicts) in Phase 1 error output to aid forensic backtracking and contractual audit trails.【F:scripts/1_parse_ai_responses.py†L90-L158】
+   - _Status update:_ Automated binary coercions are now tracked in the `phase3_coercion_flags` column and detailed repair logs, and malformed responses include the original text block for audit review.【F:scripts/1_parse_ai_responses.py†L122-L156】【F:scripts/3_repair_data_errors.py†L210-L357】
 
 3. **High – Enhance Validation Robustness**
    - Replace `str.isdigit()` checks with tolerant numeric parsers that still reject empty strings and flag negative placeholders explicitly.【F:scripts/2_validate_dataset.py†L188-L248】
    - Introduce length/character filters for free-text fields and configurable warning thresholds (e.g., future-dated decisions) to reduce silent schema drift.【F:scripts/2_validate_dataset.py†L18-L188】
+   - _Status update:_ Field validators now parse integers with explicit negative safeguards, enforce configurable future-year warnings, and apply control/placeholder filters plus max-length policies to free-text inputs.【F:scripts/2_validate_dataset.py†L196-L356】
 
 4. **Medium – Improve Enrichment Transparency**
    - Emit explicit QA flags when FX lookup relies on fallback rates or when article parsing drops sub-article references, supporting contract-grade provenance.【F:scripts/4_enrich_prepare_outputs.py†L204-L360】

--- a/scripts/schema_utils.py
+++ b/scripts/schema_utils.py
@@ -1,0 +1,79 @@
+"""Utility helpers for schema version management across pipeline phases."""
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, Sequence
+
+_DEFAULT_SCHEMA_FILES = (
+    Path('schema/main-schema-critically-important.md'),
+    Path('schema/AI-prompt-very-important.md'),
+)
+
+
+def _resolve_project_root() -> Path:
+    """Return the repository root based on this module's location."""
+    return Path(__file__).resolve().parent.parent
+
+
+def resolve_schema_files(
+    project_root: Path | None = None,
+    schema_files: Sequence[Path] = _DEFAULT_SCHEMA_FILES,
+) -> list[Path]:
+    """Return absolute schema file paths that participate in the version hash."""
+    root = project_root or _resolve_project_root()
+    resolved: list[Path] = []
+    for relative_path in schema_files:
+        path = relative_path if relative_path.is_absolute() else root / relative_path
+        if not path.exists():
+            continue
+        resolved.append(path)
+    return resolved
+
+
+def compute_schema_hash(project_root: Path | None = None) -> str:
+    """Compute a SHA256 hash for the current schema snapshot."""
+    files = resolve_schema_files(project_root)
+    digest = hashlib.sha256()
+    for path in sorted(files):
+        digest.update(path.name.encode('utf-8'))
+        digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+def snapshot_path_for_directory(directory: Path, filename: str = 'schema_snapshot.json') -> Path:
+    """Return the schema snapshot file path for a given directory."""
+    return Path(directory) / filename
+
+
+def write_schema_snapshot(
+    directory: Path,
+    schema_hash: str,
+    schema_files: Iterable[Path],
+    *,
+    filename: str = 'schema_snapshot.json',
+) -> Path:
+    """Persist the schema hash metadata next to validation/repair artefacts."""
+    directory = Path(directory)
+    directory.mkdir(parents=True, exist_ok=True)
+    snapshot_path = snapshot_path_for_directory(directory, filename)
+    payload = {
+        'schema_hash': schema_hash,
+        'schema_files': [str(Path(path).resolve()) for path in schema_files],
+        'generated': datetime.utcnow().isoformat() + 'Z',
+    }
+    snapshot_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding='utf-8')
+    return snapshot_path
+
+
+def read_schema_snapshot(snapshot_path: Path) -> dict | None:
+    """Load a schema snapshot JSON payload if it exists."""
+    path = Path(snapshot_path)
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding='utf-8'))
+    except json.JSONDecodeError:
+        return None


### PR DESCRIPTION
## Summary
- quarantine duplicate IDs and capture raw response blocks during Phase 1 parsing to aid audits
- embed and verify schema hashes across Phases 2 and 3 while expanding validation safeguards for free text and numeric fields
- record coercion flags for automated repairs, persist schema snapshots, and document the new workflow in the pipeline guides

## Testing
- python -m py_compile scripts/1_parse_ai_responses.py scripts/2_validate_dataset.py scripts/3_repair_data_errors.py scripts/schema_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68e24cd8a438832e94fe1f7df28ee8c8