### PR TITLE
Add FX metadata exports and regression tests for phase 4

### DIFF
--- a/SCRIPTS-README.md
+++ b/SCRIPTS-README.md
@@ -403,6 +403,8 @@ During development, the following values were added to schema to reflect actual 
 - Region groupings: `/raw_data/reference/region_map.csv`
 
 **Outputs:**
+- `/outputs/phase4_enrichment/0_fx_conversion_metadata.csv` – Captures FX lookup method (`MONTHLY_AVG`, `ANNUAL_AVG`, `FALLBACK`), source year/month, and converted values for fines and turnover.
+- `/outputs/phase4_enrichment/0_fx_missing_review.csv` – Summarises cases where FX conversion failed so reviewers can intervene.
 - `/outputs/phase4_enrichment/1_enriched_master.csv` – Adds temporal fields, FX/EUR normalization (nominal & real 2025 euros), sanction and Art. 83 scoring, contextual flags, OSS geography, QA signals, and keyword metadata.
 - `/outputs/phase4_enrichment/2_processing_contexts.csv` – Long table of processing contexts with positional order.
 - `/outputs/phase4_enrichment/3_vulnerable_groups.csv` – Exploded vulnerable group annotations.

--- a/data-sources-readme.md
+++ b/data-sources-readme.md
@@ -20,6 +20,8 @@ This reference explains every CSV emitted by the GDPR enforcement data pipeline 
 - `repaired_dataset_validation_report.txt`: Summary stats for the post-repair validation pass (mirrors the Phase 2 report format).
 
 ## Phase 4 – Enrichment (`outputs/phase4_enrichment/`)
+- `0_fx_conversion_metadata.csv`: Diagnostics table showing the FX lookup path (monthly, annual, fallback) for every fine and turnover entry along with source year/month and converted amounts.
+- `0_fx_missing_review.csv`: Manual-review helper listing rows where a nominal amount existed but no FX rate was available.
 - `1_enriched_master.csv`: Feature-complete master table (one row per decision) with temporal granularity, inferred dates, FX-normalized fines/turnover, 2025 EUR deflators, sanction profiles, Art. 5/83 indicators, context flags, OSS geography, QA signals, and keyword metadata.
 - `2_processing_contexts.csv`: Long table of processing contexts with decision IDs and positional order.
 - `3_vulnerable_groups.csv`: Long table of vulnerable group mentions per decision.

--- a/docs/phase4_improvement_plan.md
+++ b/docs/phase4_improvement_plan.md
@@ -9,11 +9,13 @@ Prioritise items according to research deadlines and data availability.
    - Add targeted unit tests around `compute_art5_and_rights` and `compute_measures` to ensure boolean roll-ups and QA flags
      remain stable as additional sentinel values appear.
    - Include a golden-record snapshot test for `build_graph_exports` covering node ID formatting and relationship de-duplication.
+   - *Status: Completed — pytest suite now exercises the Art. 5/right roll-ups, sanction aggregations, and graph export files.*
 
 2. **FX metadata transparency**
    - Persist a supplementary table that records FX lookup method (`MONTHLY_AVG`, `ANNUAL_AVG`, `FALLBACK`) alongside the
      source year/month so analysts can filter out fallback conversions when required.
    - Consider exposing a warning list (log or CSV) for rows lacking FX coverage to streamline manual review.
+   - *Status: Completed — enrichment now emits `0_fx_conversion_metadata.csv` and `0_fx_missing_review.csv` with conversion audit trails.*
 
 ## Medium Priority
 

--- a/readme.md
+++ b/readme.md
@@ -143,6 +143,8 @@ python3 scripts/3_repair_data_errors.py
 - Inflation reference: `/raw_data/reference/hicp_ea19.csv`
 
 **Outputs (`/outputs/phase4_enrichment/`):**
+- `0_fx_conversion_metadata.csv` – FX lookup diagnostics (method, source year/month, fallback flags) alongside nominal and converted amounts for fines and turnover.
+- `0_fx_missing_review.csv` – Manual-review queue for cases where an FX conversion was requested but no rate was resolved.
 - `1_enriched_master.csv` – 200+ engineered fields spanning temporal structure, monetary normalization (nominal & 2025 EUR), Art. 5 & 83 scoring, sanction profiles, OSS geography, QA flags, and text metadata.
 - `2_processing_contexts.csv` – Long form processing contexts with ordering metadata.
 - `3_vulnerable_groups.csv` – Exploded list of vulnerable data subjects per decision.

--- a/scripts/4_enrich_prepare_outputs.py
+++ b/scripts/4_enrich_prepare_outputs.py
@@ -969,6 +969,49 @@ def enrich_dataset(
     df = compute_text_features(df, guidelines_df)
     df = compute_quality_flags(df)
 
+    fx_metadata_columns = [
+        "id",
+        "fine_currency",
+        "fine_amount_orig",
+        "fine_amount_eur",
+        "fine_fx_method",
+        "fine_fx_year",
+        "fine_fx_month",
+        "flag_fine_fx_fallback",
+        "turnover_currency",
+        "turnover_amount_orig",
+        "turnover_amount_eur",
+        "turnover_fx_method",
+        "turnover_fx_year",
+        "turnover_fx_month",
+        "flag_turnover_fx_fallback",
+    ]
+
+    fx_metadata = df[fx_metadata_columns].copy()
+    fx_metadata.to_csv(output_dir / "0_fx_conversion_metadata.csv", index=False)
+
+    fx_missing = df[
+        (
+            df["fine_amount_orig"].notna()
+            & df["fine_amount_eur"].isna()
+        )
+        | (
+            df["turnover_amount_orig"].notna()
+            & df["turnover_amount_eur"].isna()
+        )
+    ][
+        [
+            "id",
+            "fine_currency",
+            "fine_amount_orig",
+            "fine_fx_method",
+            "turnover_currency",
+            "turnover_amount_orig",
+            "turnover_fx_method",
+        ]
+    ].copy()
+    fx_missing.to_csv(output_dir / "0_fx_missing_review.csv", index=False)
+
     df.to_csv(output_dir / "1_enriched_master.csv", index=False)
     contexts_df.to_csv(output_dir / "2_processing_contexts.csv", index=False)
     vulnerable_df.to_csv(output_dir / "3_vulnerable_groups.csv", index=False)

--- a/tests/test_phase4_enrichment.py
+++ b/tests/test_phase4_enrichment.py
@@ -1,0 +1,240 @@
+import importlib.util
+from pathlib import Path
+
+import pandas as pd
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "4_enrich_prepare_outputs.py"
+spec = importlib.util.spec_from_file_location("phase4_enrichment", MODULE_PATH)
+phase4 = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(phase4)
+
+
+def test_compute_art5_and_rights_handles_profiles_and_gaps():
+    df = pd.DataFrame(
+        [
+            {
+                "id": "CASE1",
+                "a21_art5_lawfulness_fairness": "BREACHED",
+                "a22_art5_purpose_limitation": "NO",
+                "a23_art5_data_minimization": "NO",
+                "a24_art5_accuracy": "NO",
+                "a25_art5_storage_limitation": "NO",
+                "a26_art5_integrity_confidentiality": "NO",
+                "a27_art5_accountability": "NO",
+                "a37_right_access_violated": "YES",
+                "a38_right_rectification_violated": "NO",
+                "a39_right_erasure_violated": "NOT_DISCUSSED",
+                "a40_right_restriction_violated": "NO",
+                "a41_right_portability_violated": "NO",
+                "a42_right_object_violated": "NO",
+                "a43_transparency_violated": "NO",
+                "a44_automated_decisions_violated": "NO",
+            },
+            {
+                "id": "CASE2",
+                "a21_art5_lawfulness_fairness": "BREACHED",
+                "a22_art5_purpose_limitation": "BREACHED",
+                "a23_art5_data_minimization": "NO",
+                "a24_art5_accuracy": "NO",
+                "a25_art5_storage_limitation": "NO",
+                "a26_art5_integrity_confidentiality": "NO",
+                "a27_art5_accountability": "NO",
+                "a37_right_access_violated": "YES",
+                "a38_right_rectification_violated": "YES",
+                "a39_right_erasure_violated": "NO",
+                "a40_right_restriction_violated": "NO",
+                "a41_right_portability_violated": "NO",
+                "a42_right_object_violated": "NO",
+                "a43_transparency_violated": "NO",
+                "a44_automated_decisions_violated": "NO",
+            },
+        ]
+    )
+
+    articles_df = pd.DataFrame(
+        [
+            {
+                "id": "CASE1",
+                "article_reference": "Art. 5(1)(a)",
+                "article_reference_detail": "5(1)(a)",
+                "article_detail_tokens": "1;a",
+                "article_label": "5",
+                "article_number": 5,
+                "position": 1,
+            },
+            {
+                "id": "CASE1",
+                "article_reference": "Art. 15",
+                "article_reference_detail": "15",
+                "article_detail_tokens": "",
+                "article_label": "15",
+                "article_number": 15,
+                "position": 2,
+            },
+            {
+                "id": "CASE2",
+                "article_reference": "Art. 6",
+                "article_reference_detail": "6",
+                "article_detail_tokens": "",
+                "article_label": "6",
+                "article_number": 6,
+                "position": 1,
+            },
+        ]
+    )
+
+    result = phase4.compute_art5_and_rights(df.copy(), articles_df)
+
+    assert result.loc[result["id"] == "CASE1", "rights_violated_count"].iloc[0] == 1
+    assert result.loc[result["id"] == "CASE1", "rights_profile"].iloc[0] == "A15"
+    assert bool(result.loc[result["id"] == "CASE1", "flag_articles_vs_rights_gap"].iloc[0]) is False
+
+    assert result.loc[result["id"] == "CASE2", "rights_violated_count"].iloc[0] == 2
+    assert result.loc[result["id"] == "CASE2", "rights_profile"].iloc[0] == "A15;A16"
+    assert bool(result.loc[result["id"] == "CASE2", "flag_articles_vs_rights_gap"].iloc[0]) is True
+    assert bool(result.loc[result["id"] == "CASE2", "breach_has_art5"].iloc[0]) is True
+    assert bool(
+        result.loc[result["id"] == "CASE2", "flag_art5_breached_but_5_not_in_77"].iloc[0]
+    ) is True
+
+
+def test_compute_measures_rolls_up_flags():
+    df = pd.DataFrame(
+        [
+            {
+                "id": "CASE1",
+                "a45_warning_issued": "YES",
+                "a46_reprimand_issued": "NO",
+                "a47_comply_data_subject_order": "NO",
+                "a48_compliance_order": "NO",
+                "a49_breach_communication_order": "NO",
+                "a50_erasure_restriction_order": "NO",
+                "a51_certification_withdrawal": "NO",
+                "a52_data_flow_suspension": "NO",
+                "a53_fine_imposed": "NO",
+            },
+            {
+                "id": "CASE2",
+                "a45_warning_issued": "NO",
+                "a46_reprimand_issued": "YES",
+                "a47_comply_data_subject_order": "NO",
+                "a48_compliance_order": "YES",
+                "a49_breach_communication_order": "NO",
+                "a50_erasure_restriction_order": "NO",
+                "a51_certification_withdrawal": "NO",
+                "a52_data_flow_suspension": "NO",
+                "a53_fine_imposed": "YES",
+            },
+        ]
+    )
+    df["fine_imposed_bool"] = df["a53_fine_imposed"].apply(phase4.yes_no_to_bool)
+
+    result = phase4.compute_measures(df.copy())
+
+    case1 = result[result["id"] == "CASE1"].iloc[0]
+    assert bool(case1["measure_any_bool"]) is True
+    assert case1["measure_count"] == 1
+    assert case1["sanction_profile"] == "Warning"
+    assert bool(case1["is_warning_only"]) is True
+    assert bool(case1["is_fine_only"]) is False
+
+    case2 = result[result["id"] == "CASE2"].iloc[0]
+    assert bool(case2["measure_any_bool"]) is True
+    assert case2["measure_count"] == 2
+    assert case2["sanction_profile"] == "ComplianceOrder"
+    assert bool(case2["is_warning_only"]) is False
+    assert bool(case2["is_fine_only"]) is False
+
+
+def test_build_graph_exports_writes_expected_nodes_and_edges(tmp_path):
+    enriched_df = pd.DataFrame(
+        [
+            {
+                "id": "CASE1",
+                "decision_year": 2022,
+                "country_code": "DE",
+                "fine_amount_eur": 1000.0,
+                "sanction_profile": "Warning",
+                "authority_name_norm": "Bavarian DPA",
+                "a7_defendant_name": "Acme GmbH",
+                "a8_defendant_class": "PRIVATE",
+                "a9_enterprise_size": "SME",
+                "a12_sector": "TECH",
+            },
+            {
+                "id": "CASE2",
+                "decision_year": 2023,
+                "country_code": "FR",
+                "fine_amount_eur": 2500.0,
+                "sanction_profile": "ComplianceOrder",
+                "authority_name_norm": "Bavarian DPA",
+                "a7_defendant_name": "Acme GmbH",
+                "a8_defendant_class": "PRIVATE",
+                "a9_enterprise_size": "SME",
+                "a12_sector": "TECH",
+            },
+        ]
+    )
+
+    contexts_df = pd.DataFrame(
+        [
+            {"id": "CASE1", "processing_context": "CCTV", "position": 1},
+            {"id": "CASE1", "processing_context": "CCTV", "position": 2},
+            {"id": "CASE2", "processing_context": "HR", "position": 1},
+        ]
+    )
+
+    guidelines_df = pd.DataFrame(
+        [
+            {"id": "CASE1", "guideline": "WP29", "position": 1},
+            {"id": "CASE2", "guideline": "EDPB", "position": 1},
+        ]
+    )
+
+    articles_df = pd.DataFrame(
+        [
+            {
+                "id": "CASE1",
+                "article_reference": "Art. 5",
+                "article_reference_detail": "5",
+                "article_detail_tokens": "",
+                "article_label": "5",
+                "article_number": 5,
+                "position": 1,
+            },
+            {
+                "id": "CASE2",
+                "article_reference": "Art. 6",
+                "article_reference_detail": "6",
+                "article_detail_tokens": "",
+                "article_label": "6",
+                "article_number": 6,
+                "position": 1,
+            },
+        ]
+    )
+
+    phase4.build_graph_exports(enriched_df, contexts_df, guidelines_df, articles_df, tmp_path)
+
+    graph_dir = tmp_path / "graph"
+
+    decision_nodes = pd.read_csv(graph_dir / "nodes_decision.csv").sort_values("id").reset_index(drop=True)
+    assert decision_nodes["id:ID"].tolist() == ["Decision|CASE1", "Decision|CASE2"]
+
+    authority_nodes = pd.read_csv(graph_dir / "nodes_authority.csv")
+    assert authority_nodes["id:ID"].unique().tolist() == ["Authority|BAVARIAN_DPA"]
+
+    edges_authority = pd.read_csv(graph_dir / "edges_decision_authority.csv")
+    assert len(edges_authority) == 2
+    assert edges_authority[":END_ID"].unique().tolist() == ["Authority|BAVARIAN_DPA"]
+
+    edges_context = pd.read_csv(graph_dir / "edges_decision_context.csv")
+    assert len(edges_context) == 2
+    assert set(edges_context[":END_ID"]) == {"Context|CCTV", "Context|HR"}
+
+    edges_article = pd.read_csv(graph_dir / "edges_decision_article.csv")
+    assert len(edges_article) == 2
+    assert set(edges_article[":END_ID"]) == {"Article|5", "Article|6"}
+
+    edges_guideline = pd.read_csv(graph_dir / "edges_decision_guideline.csv")
+    assert set(edges_guideline[":END_ID"]) == {"Guideline|WP29", "Guideline|EDPB"}


### PR DESCRIPTION
## Summary
- emit dedicated FX conversion metadata and missing-coverage review tables from the phase 4 enrichment pipeline
- document the new enrichment artefacts across repository readmes and mark the improvement plan items as completed
- add pytest coverage for Art. 5/right roll-ups, sanction aggregations, and graph export generation to guard against regressions

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e261898750832e9ef7930c1ee86e9c