### PR TITLE
Handle duplicate breach notification columns in task3

### DIFF
--- a/research_tasks/task4.py
+++ b/research_tasks/task4.py
@@ -128,7 +128,13 @@ def _authority_factor_summary(df: pd.DataFrame) -> pd.DataFrame:
         coverage_std = float(group["factor_coverage"].std(ddof=0)) if len(group) > 1 else 0.0
         direction_mean = float(group["direction_ratio"].mean())
         balance_mean = float(group["art83_balance_score"].mean())
-        systematic_share = float(group["art83_systematic_bool"].mean())
+        systematic_series = pd.to_numeric(
+            group["art83_systematic_bool"], errors="coerce"
+        )
+        if systematic_series.notna().any():
+            systematic_share = float(systematic_series.mean())
+        else:
+            systematic_share = float("nan")
         coherence = _spearman_coherence(group)
         fine_std = float(group.loc[group["fine_amount_log"].notna(), "fine_amount_log"].std(ddof=0))
         measure_std = float(group["measure_count"].astype(float).std(ddof=0))


### PR DESCRIPTION
## Summary
- avoid loading `breach_notification_effect_num` twice for task3 by removing it from the extra column request
- derive the self-report flag from whichever breach-notification series exists after merging and fall back to zeros when unavailable
- coerce `art83_systematic_bool` to numeric before aggregating authority summaries so NA markers don't raise type errors

## Testing
- python3 run_research_tasks.py --tasks task3 *(fails: ModuleNotFoundError: No module named 'pandas')*
- python3 run_research_tasks.py --tasks task4 *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68e2b4682528832e93326b6ecf1f0ed9